### PR TITLE
Issue FlavioAdamo#34 plus 'cant search names with spaces' bug resolved

### DIFF
--- a/Script/script.js
+++ b/Script/script.js
@@ -74,7 +74,10 @@ function loadCollapse(sortType, searchVal = '') {
         countryData.push(data);
     }
 
-    countryData = (searchVal != "") ? countryData.filter(x => ((x['name'].replace(/\s+/g, '')).toLowerCase()).includes(searchVal.toLowerCase())) : countryData;
+    // (1/3) You had removed all spaces from the countryData.name (to remove the space before all names bug), therefore searching
+    // (2/3) anything with a space in it resulted in no results as ' ' was not in countryData.name at all. I added the new .replace()
+    // (3/3) so only the first space of each countryData.name is removed (if there is one). Now you can search for names with spaces. Cheers.
+    countryData = (searchVal != "") ? countryData.filter(x => ((x['name'].replace(/^ /, '')).toLowerCase()).includes(searchVal.toLowerCase())) : countryData;
 
     $('.countryCard').remove();
 

--- a/Style/style.css
+++ b/Style/style.css
@@ -325,11 +325,16 @@
     height: fit-content;
 }
 .search{
-    width: 100%;
-    border: none;
-    padding: 10px 0px 10px 50px;
-    border-radius: 5px;
-    box-shadow: rgb(0 0 0 / 3%) 0px 4px 10px -1px, rgb(0 0 0 / 1%) 0px 2px 4px -1px
+  transition: 0.3s;
+  width: 100%;
+  border: none;
+  padding: 10px 0px 10px 50px;
+  border-radius: 5px;
+  box-shadow: rgb(0 0 0 / 3%) 0px 4px 10px -1px, rgb(0 0 0 / 1%) 0px 2px 4px -1px
+}
+.search:hover{
+  transition: 0.3s;
+  box-shadow: rgb(0 0 0 / 15%) 0px 4px 10px -1px, rgb(0 0 0 / 7.5%) 0px 2px 4px -1px
 }
 .search-icon{
   position: absolute;
@@ -340,5 +345,5 @@
 }
 .search:focus{
   outline: none;
+  box-shadow: rgb(0 0 0 / 15%) 0px 4px 10px -1px, rgb(0 0 0 / 7.5%) 0px 2px 4px -1px
 }
-

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
 <body>
   <div class="page">
     <nav class="navbar fixed-top bg-light navbar-light" style="font-family: 'Lato', sans-serif;">
+      <div class="test"></div>
       <div class="container" style="padding-left:0px">
         <a class="navbar-brand topTitle" href="/"><img id="navLogo" alt="covidvaccinetrack logo" src="Images/Logo.png"
             width="170px"></a>
@@ -98,7 +99,7 @@
             </div>
             <div style="position: relative;" class="col-sm-12 col-md-7 deletepadding">
               <img src="Images/Search.png" class="search-icon" alt="">
-              <input class="float-right search" type="search" name="search" placeholder="Search for Continents or Countries" id="search">
+              <input class="float-right search" type="search" autocomplete="off" name="search" placeholder="Search for Continents or Countries" id="search">
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
 <body>
   <div class="page">
     <nav class="navbar fixed-top bg-light navbar-light" style="font-family: 'Lato', sans-serif;">
-      <div class="test"></div>
       <div class="container" style="padding-left:0px">
         <a class="navbar-brand topTitle" href="/"><img id="navLogo" alt="covidvaccinetrack logo" src="Images/Logo.png"
             width="170px"></a>


### PR DESCRIPTION
Issue FlavioAdamo#34 resolved: Added deeper search bar shadow on hover and focus, also turned autocomplete off (no need for it, can look ugly). Noticed bug when searching - You had removed all spaces from the countryData.name (to remove the space before all names bug), therefore searching anything with a space in it resulted in no results as ' ' was not in countryData.name at all. I added the new .replace() so only the first space of each countryData.name is removed (if there is one). Now you can search for names with spaces.

The second 'index.html' commit was just getting rid of a test div btw - necessary of course, but the previous one is of more interest.

Cheers.