### PR TITLE
Issue 49: Added function to format difference counter

### DIFF
--- a/Script/data.js
+++ b/Script/data.js
@@ -92,3 +92,7 @@ function formatNumberWithCommas(number) {
     // Just read the name of the function
     return parseInt(number).toLocaleString();
 }
+
+function formatDifferenceWithCommas(number) {
+    return '+' + parseInt(number.substring(1)).toLocaleString();
+}

--- a/Script/script.js
+++ b/Script/script.js
@@ -94,7 +94,7 @@ function loadCollapse(sortType, searchVal = '') {
             CONTENT.querySelector('.countryname').innerHTML = country.name;
             CONTENT.querySelector('.position').innerHTML = country.position;
             CONTENT.querySelector('.populationpercent').innerHTML = `<img alt="syringe" src="Images/Population.png" style="height:14px;"> ${country.vaccinatedPercent}`;
-            CONTENT.querySelector('.differenceCounter').innerHTML = country.totalVaccineDifferences;
+            CONTENT.querySelector('.differenceCounter').innerHTML = formatDifferenceWithCommas(country.totalVaccineDifferences);
             CONTENT.querySelector('.accordion').parentNode.classList.add("countryCard");
 
             // Set attribute
@@ -175,7 +175,7 @@ function loadContinents(sortType, searchVal = '') {
             CONTENT.querySelector('.countryname').innerHTML = continent.name;
             CONTENT.querySelector('.position').innerHTML = continent.position;
             CONTENT.querySelector('.populationpercent').innerHTML = `<img alt="syringe" src="Images/Population.png" style="height:14px;"> ${continent.vaccinatedPercent}`;
-            CONTENT.querySelector('.differenceCounter').innerHTML = continent.totalVaccineDifferences;
+            CONTENT.querySelector('.differenceCounter').innerHTML = formatDifferenceWithCommas(continent.totalVaccineDifferences);
             CONTENT.querySelector('.accordion').parentNode.classList.add("continentCard");
 
             // Set attribute


### PR DESCRIPTION
I added another function which formats the difference counter using `toLocaleString()`.
I didn't want to use formatNumberWithCommas() for this because you'd have to use `'+' + formatNumberWithCommas(country.totalVaccineDifferences.substring(1))` every time, which is quite untidy in my opinion.