### PR TITLE
Change map projection

### DIFF
--- a/Script/script.js
+++ b/Script/script.js
@@ -406,6 +406,9 @@ function drawRegionsMap(countryLastData = countryLastData, useCase = 0) {
         backgroundColor: '#f8f9fa',
         width: $(document.querySelector('#map-holder')).width()*1,
         height: $(document.querySelector('#map-holder')).height()*1,
+        projection: {
+          name: 'kavrayskiy-vii',
+        }
         };
 
 


### PR DESCRIPTION
Hello! This PR changes the map projection from `Mercator` to `Kavrayskiy VII`.

In my opinion, the current [map projection](https://en.wikipedia.org/wiki/Map_projection) doesn't look very good for displaying data. While it may be good for navigation purposes (which is what it was designed for), it distorts the northern hemisphere so much that Greenland appears to be as big as Africa when in reality, it's fourteen times smaller.

**Mercator projection**
![Screenshot_2021-06-05 Covid Vaccine Track World - All countries DATA](https://user-images.githubusercontent.com/82605039/120890754-05d65200-c605-11eb-9096-d992da90e692.png)

**Kavrayskiy VII projection**
![Screenshot_2021-06-05 Covid Vaccine Track World - All countries DATA 2](https://user-images.githubusercontent.com/82605039/120890772-22728a00-c605-11eb-8e68-639d863ce9a2.png)

This also fixes the overlapping of Chile/Argentina with the color axis.

There are some drawbacks though:
- It makes clicking countries in the northern hemisphere, especially those in Europe, more difficult as they are now smaller compared to the Mercator projection.
- More importantly, it is implemented by adding a `projection` object to the `options` passed into `chart.draw()`. This feature is not documented and experimental, which may be a reason not to use it. For further information, please refer to this stackoverflow thread: https://stackoverflow.com/a/20333511

What are your opinions on this?
